### PR TITLE
Refactoring and doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,12 @@ PROJECT_NAME = predicting-cat-5-damage-to-buildings
 PYTHON_INTERPRETER = python3
 PYTHON_ENV_VERSION = 3.9
 
+ifeq (,$(shell which mamba))
+HAS_MAMBA=False
+else
+HAS_MAMBA=True
+endif
+
 ifeq (,$(shell which conda))
 HAS_CONDA=False
 else
@@ -34,6 +40,14 @@ format:
 
 ## Set up python interpreter environment and install basic dependencies
 create_environment:
+ifeq (True,$(HAS_MAMBA))
+	@echo ">>> Detected mamba, creating mamba environment/."
+
+		# Create the conda environment
+	mamba env create --prefix=./env -f requirements/environment.yml
+
+	@echo ">>> New mamba env created. Activate from project directory with:\nmamba activate ./env"
+else
 ifeq (True,$(HAS_CONDA))
 	@echo ">>> Detected conda, creating conda environment."
 	
@@ -48,6 +62,7 @@ else
 	export WORKON_HOME=$$HOME/.virtualenvs\nexport PROJECT_HOME=$$HOME/Devel\nsource /usr/local/bin/virtualenvwrapper.sh\n"
 	@bash -c "source `which virtualenvwrapper.sh`;mkvirtualenv $(PROJECT_NAME) --python=$(PYTHON_INTERPRETER)"
 	@echo ">>> New virtualenv created. Activate with:\nworkon $(PROJECT_NAME)"
+endif
 endif
 
 ## Install and set up handy jupyter notebook extensions

--- a/src/data_loading/patch_utils.py
+++ b/src/data_loading/patch_utils.py
@@ -23,14 +23,14 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 def get_indices_for_point(bounds_list: List, point: Point) -> List:
     """
-    PARAMETERS:
-    --- 
-    bounds_list: a list of BoundingBox
-    point: a Point object from shapely
+    Parameters
+    ----------
+    bounds_list : a list of BoundingBox
+    point : shapely.geometry.point.Point
 
-    RETURNS:
-    ---
-    indices: a list of indices
+    Returns
+    -------
+    res : a list of indices
         for each index i, bounds_list[i] is a bound that contains the point
     """
     res = []

--- a/src/data_loading/patch_utils.py
+++ b/src/data_loading/patch_utils.py
@@ -165,7 +165,7 @@ def main(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True) -> None:
     os.makedirs(path_to_hurricane_patches_pre, exist_ok=True)
     os.makedirs(path_to_hurricane_patches_post, exist_ok=True)
 
-    for (point, idx) in zip(gdf.geometry, range(len(gdf))):
+    for idx, point in enumerate(gdf.geometry):
         crop_patches_for_point(pre_event_links, pre_event_bounds, point, idx, 20, path_to_hurricane_patches_pre,
                                toprint)
         crop_patches_for_point(post_event_links, post_event_bounds, point, idx, 20, path_to_hurricane_patches_post,

--- a/src/data_loading/patch_utils.py
+++ b/src/data_loading/patch_utils.py
@@ -43,7 +43,17 @@ def get_indices_for_point(bounds_list: List, point: Point) -> List:
 def get_geom_for_point(point: Point, dist: float):
     """
     Create a BoundingBox with the point at the center. 
-    Each edge is at a distance of dist meters from the point
+    Each edge is at a distance of dist meters from the point.
+
+    Parameters
+    ----------
+    point : shapely.geometry.point.Point
+    dist : float
+
+    Returns
+    -------
+    geodf : geopandas.geodataframe.GeoDataFrame
+        geodataframe of the bounding box
     """
     deg = convert_meters_to_deg(dist)
     left, right, top, bottom = (point.x - deg, point.x + deg, point.y + deg, point.y - deg)

--- a/src/data_loading/patch_utils.py
+++ b/src/data_loading/patch_utils.py
@@ -115,8 +115,10 @@ def crop_patches_for_point(
     print_message(toprint, "Setting up...")
     geodf = get_geom_for_point(point, dist)
     (left, bottom, right, top) = geodf.geometry[0].bounds
+
     print_message(toprint, "Getting list of indices for point...")
     indices = get_indices_for_point(bounds_list, point)
+
     print_message(toprint, f"Cropping from a total of {len(indices)} images...")
     for idx, i in enumerate(indices):
         print_message(toprint, f"{idx + 1}/{len(indices)}", end="\r")

--- a/src/data_loading/patch_utils.py
+++ b/src/data_loading/patch_utils.py
@@ -97,7 +97,7 @@ def crop_patches_for_point(
         dist: float,
         path_to_dir: str,
         toprint: bool = True
-    ):
+) -> None:
     """
     PARAMETERS:
     ---

--- a/src/data_loading/patch_utils.py
+++ b/src/data_loading/patch_utils.py
@@ -1,18 +1,22 @@
-from email import contentmanager
-import shapely
-import sys
+# from email import contentmanager
 import os
+import sys
+import affine
+import numpy as np
+import geopandas as gpd
 import rasterio as rio
 
-from src.data_loading.utils import *
-from src.data_loading.tif_links_utils import *
-from src.data_loading.vector_data_utils import *
+from typing import List
+
 from rasterio.windows import from_bounds
 from rasterio.io import MemoryFile
 from rasterio.crs import CRS
 from shapely.geometry.point import Point
 from shapely.geometry import box
-from typing import Counter, List
+
+from src.data_loading.vector_data_utils import check_point_in_bounding_box, combine_all_vector_data_and_save_for_hurricane
+from src.data_loading.tif_links_utils import get_tidied_tif_links
+from src.data_loading.utils import convert_meters_to_deg, print_message, PATH_TO_PATCHES, DEFAULT_HURRICANE
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 

--- a/src/data_loading/patch_utils.py
+++ b/src/data_loading/patch_utils.py
@@ -30,7 +30,7 @@ def get_indices_for_point(bounds_list: List, point: Point) -> List:
         for each index i, bounds_list[i] is a bound that contains the point
     """
     res = []
-    for (bound, idx) in zip(bounds_list, range(len(bounds_list))):
+    for idx, bound in enumerate(bounds_list):
         if check_point_in_bounding_box(point, bound):
             res.append(idx)
     return res
@@ -84,7 +84,7 @@ def crop_patches_for_point(
     print_message(toprint, "Getting list of indices for point...")
     indices = get_indices_for_point(bounds_list, point)
     print_message(toprint, f"Cropping from a total of {len(indices)} images...")
-    for (idx, i) in zip(indices, range(len(indices))):
+    for idx, i in enumerate(indices):
         print_message(toprint, f"{idx + 1}/{len(indices)}", end="\r")
         link = links[idx]
         with rio.open(link) as src:

--- a/src/data_loading/patch_utils.py
+++ b/src/data_loading/patch_utils.py
@@ -67,6 +67,20 @@ def get_geom_for_point(point: Point, dist: float):
 
 
 def create_dataset(data: np.ndarray, crs: CRS, count: int, transform: affine.Affine) -> rio.io.DatasetReader:
+    """Open a rasterio memory file as a rasterio dataset
+
+    Parameters
+    ----------
+    data : np.ndarray
+    crs: rasterio.crs.CRS
+        crs to use for the dataset
+    count : int
+    transform : affine.Affine
+
+    Returns
+    -------
+    dataset : rio.io.DatasetReader
+    """
     # Receives a 2D array, a transform and a crs to create a rasterio dataset
     memfile = MemoryFile()
     dataset = memfile.open(driver='GTiff', height=data.shape[1], width=data.shape[2], count=count, crs=crs,

--- a/src/data_loading/patch_utils.py
+++ b/src/data_loading/patch_utils.py
@@ -83,7 +83,7 @@ def create_dataset(data: np.ndarray, crs: CRS, count: int, transform: affine.Aff
     """
     # Receives a 2D array, a transform and a crs to create a rasterio dataset
     memfile = MemoryFile()
-    dataset = memfile.open(driver='GTiff', height=data.shape[1], width=data.shape[2], count=count, crs=crs,
+    dataset = memfile.open(driver="GTiff", height=data.shape[1], width=data.shape[2], count=count, crs=crs,
                            transform=transform, dtype=data.dtype)
     dataset.write(data)
     return dataset
@@ -127,8 +127,8 @@ def crop_patches_for_point(
         print_message(toprint, "Saving...")
         filename = os.path.join(path_to_dir, f"{point_idx}-{i + 1}.tif")
         with rio.open(
-                filename, 'w',
-                driver='GTiff',
+                filename, "w",
+                driver="GTiff",
                 width=clipped.shape[2],
                 height=clipped.shape[1],
                 count=count,

--- a/src/data_loading/patch_utils.py
+++ b/src/data_loading/patch_utils.py
@@ -99,12 +99,18 @@ def crop_patches_for_point(
         toprint: bool = True
 ) -> None:
     """
-    PARAMETERS:
-    ---
-        links: a list of links
-        bounds_list: a list of BoundingBox from rasterio.coords 
-        point: the point that we want to crop patches for
-        path_to_dir: path to the directory in which we will store all the patches
+    Parameters
+    ----------
+    links : list
+    bounds_list : list
+        rasterio.coords.BoundingBox
+    point : shapely.geometry.point.Point
+    point_idx : int
+    dist : float
+    path_to_dir : str
+        path to the directory in which we will store all the patches
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
     """
     print_message(toprint, "Setting up...")
     geodf = get_geom_for_point(point, dist)

--- a/src/data_loading/patch_utils.py
+++ b/src/data_loading/patch_utils.py
@@ -1,20 +1,23 @@
 from email import contentmanager
+import shapely
 import sys
 import os
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from data_loading.utils import *
-from data_loading.tif_links_utils import *
-from data_loading.vector_data_utils import *
 import rasterio as rio
+
+from src.data_loading.utils import *
+from src.data_loading.tif_links_utils import *
+from src.data_loading.vector_data_utils import *
 from rasterio.windows import from_bounds
 from rasterio.io import MemoryFile
 from rasterio.crs import CRS
-import shapely
 from shapely.geometry.point import Point
 from shapely.geometry import box
 from typing import Counter, List
 
-def get_indices_for_point(bounds_list: List, point: Point):
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+
+def get_indices_for_point(bounds_list: List, point: Point) -> List:
     """
     PARAMETERS:
     --- 
@@ -32,31 +35,41 @@ def get_indices_for_point(bounds_list: List, point: Point):
             res.append(idx)
     return res
 
-def get_geom_for_point(point: Point, dist):
+
+def get_geom_for_point(point: Point, dist: float):
     """
     Create a BoundingBox with the point at the center. 
     Each edge is at a distance of dist meters from the point
     """
     deg = convert_meters_to_deg(dist)
-    left, right, top, bottom = (point.x - deg, point.x+deg, point.y+deg, point.y-deg)
+    left, right, top, bottom = (point.x - deg, point.x + deg, point.y + deg, point.y - deg)
     geodf = gpd.GeoDataFrame(
         geometry=[
             box(left, bottom, right, top)
         ],
-        crs="EPSG:4326" # use lat lon crs system
+        crs="EPSG:4326"  # use lat lon crs system
     )
     return geodf
 
 
-def create_dataset(data:np.ndarray, crs:CRS, count:int, transform:affine.Affine) -> rio.io.DatasetReader:
-  # Receives a 2D array, a transform and a crs to create a rasterio dataset
-  memfile = MemoryFile()
-  dataset = memfile.open(driver='GTiff', height=data.shape[1], width=data.shape[2], count=count, crs=crs, 
-                          transform=transform, dtype=data.dtype)
-  dataset.write(data)
-  return dataset
+def create_dataset(data: np.ndarray, crs: CRS, count: int, transform: affine.Affine) -> rio.io.DatasetReader:
+    # Receives a 2D array, a transform and a crs to create a rasterio dataset
+    memfile = MemoryFile()
+    dataset = memfile.open(driver='GTiff', height=data.shape[1], width=data.shape[2], count=count, crs=crs,
+                           transform=transform, dtype=data.dtype)
+    dataset.write(data)
+    return dataset
 
-def crop_patches_for_point(links: List, bounds_list: List, point: Point, point_idx, dist, path_to_dir, toprint = True):
+
+def crop_patches_for_point(
+        links: List,
+        bounds_list: List,
+        point: Point,
+        point_idx: int,
+        dist: float,
+        path_to_dir: str,
+        toprint: bool = True
+    ):
     """
     PARAMETERS:
     ---
@@ -72,32 +85,33 @@ def crop_patches_for_point(links: List, bounds_list: List, point: Point, point_i
     indices = get_indices_for_point(bounds_list, point)
     print_message(toprint, f"Cropping from a total of {len(indices)} images...")
     for (idx, i) in zip(indices, range(len(indices))):
-        print_message(toprint, f"{idx+1}/{len(indices)}",end="\r")
+        print_message(toprint, f"{idx + 1}/{len(indices)}", end="\r")
         link = links[idx]
         with rio.open(link) as src:
             window = from_bounds(
                 left, bottom, right, top, src.transform,
-                )
+            )
             window_transform = src.window_transform(window)
             clipped = src.read(window=window)
             crs = src.crs
             count = src.count
         print_message(toprint, f"Clipped data has shape: {clipped.shape}")
-        print_message(toprint,"Saving...")
-        filename = os.path.join(path_to_dir, f"{point_idx}-{i+1}.tif")
+        print_message(toprint, "Saving...")
+        filename = os.path.join(path_to_dir, f"{point_idx}-{i + 1}.tif")
         with rio.open(
-            filename, 'w',
-            driver='GTiff', 
-            width=clipped.shape[2], 
-            height=clipped.shape[1], 
-            count=count,
-            transform=window_transform, 
-            crs=crs, 
-            dtype=clipped.dtype,
-            ) as dst:
+                filename, 'w',
+                driver='GTiff',
+                width=clipped.shape[2],
+                height=clipped.shape[1],
+                count=count,
+                transform=window_transform,
+                crs=crs,
+                dtype=clipped.dtype,
+        ) as dst:
             dst.write(clipped)
 
-def main(hurricane_name = DEFAULT_HURRICANE, toprint = True):
+
+def main(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True) -> None:
     links = get_tidied_tif_links(hurricane_name, toprint)
     pre_event_links = [link for link in links if "pre-event" in link]
     post_event_links = [link for link in links if "post-event" in link]
@@ -107,17 +121,20 @@ def main(hurricane_name = DEFAULT_HURRICANE, toprint = True):
     gdf = combine_all_vector_data_and_save_for_hurricane(hurricane_name, toprint)
     if len(gdf) == 0:
         raise Exception(f"No processed vector data for hurricane {hurricane_name}")
-    
+
     path_to_hurricane_patches = os.path.join(PATH_TO_PATCHES, hurricane_name)
     path_to_hurricane_patches_pre = os.path.join(path_to_hurricane_patches, "pre")
     path_to_hurricane_patches_post = os.path.join(path_to_hurricane_patches, "post")
-    os.makedirs(path_to_hurricane_patches, exist_ok = True)
-    os.makedirs(path_to_hurricane_patches_pre, exist_ok = True)
-    os.makedirs(path_to_hurricane_patches_post, exist_ok = True)
-    
-    for (point,idx) in zip(gdf.geometry,range(len(gdf))):
-        crop_patches_for_point(pre_event_links, pre_event_bounds, point, idx, 20, path_to_hurricane_patches_pre, toprint)
-        crop_patches_for_point(post_event_links, post_event_bounds, point, idx, 20, path_to_hurricane_patches_post, toprint)
+    os.makedirs(path_to_hurricane_patches, exist_ok=True)
+    os.makedirs(path_to_hurricane_patches_pre, exist_ok=True)
+    os.makedirs(path_to_hurricane_patches_post, exist_ok=True)
+
+    for (point, idx) in zip(gdf.geometry, range(len(gdf))):
+        crop_patches_for_point(pre_event_links, pre_event_bounds, point, idx, 20, path_to_hurricane_patches_pre,
+                               toprint)
+        crop_patches_for_point(post_event_links, post_event_bounds, point, idx, 20, path_to_hurricane_patches_post,
+                               toprint)
+
 
 if __name__ == "__main__":
     hurricane_name = input("Please input hurricane name (Press enter to use default test data):")

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -66,7 +66,8 @@ def tidy_up_tif_links(links: List, hurricane_name: str, toprint: bool = True, ov
     before_count = len(links)
     print_message(toprint, f"Tidying up a total of {before_count} links...")
     # Only want tif files with band >= 3
-    for (link, idx) in zip(links, list(range(before_count))):
+    # for (link, idx) in zip(links, list(range(before_count))):
+    for idx, link in enumerate(links):
         print_message(toprint, f"{idx + 1}/{before_count}", end="\r")
         try:
             src = rio.open(link)
@@ -109,7 +110,8 @@ def find_useful_links_for_box(links: List, box: BoundingBox, toprint: bool = Tru
     """
     before_count = len(links)
     res = []
-    for (link, idx) in zip(links, list(range(before_count))):
+    # for (link, idx) in zip(links, list(range(before_count))):
+    for idx, link in enumerate(links):
         print_message(toprint, f"{idx + 1}/{before_count}")
         src = rio.open(link)
         if not rio.coords.disjoint_bounds(box, src.bounds):

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -203,7 +203,8 @@ def make_bounding_box_and_find_useful_links(
     useful_post_event_links = find_useful_links_for_box(post_event_links, box, toprint)
     print_message(toprint, f"Found {len(pre_event_links)} pre event links")
     print_message(toprint, f"Found {len(post_event_links)} post event links")
-    return (box, useful_pre_event_links, useful_post_event_links)
+
+    return box, useful_pre_event_links, useful_post_event_links
 
 
 def get_list_of_bounds_for_hurricane(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True) -> dict:

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -196,8 +196,10 @@ def make_bounding_box_and_find_useful_links(
     pre_event_links = [link for link in links if "pre-event" in link]
     post_event_links = [link for link in links if "post-event" in link]
     print_message(toprint, "Finding pre event links...")
+
     useful_pre_event_links = find_useful_links_for_box(pre_event_links, box, toprint)
     print_message(toprint, "Finding post event links...")
+
     useful_post_event_links = find_useful_links_for_box(post_event_links, box, toprint)
     print_message(toprint, f"Found {len(pre_event_links)} pre event links")
     print_message(toprint, f"Found {len(post_event_links)} post event links")

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -126,7 +126,7 @@ def get_tidied_tif_links(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool 
     if not os.path.isfile(file_list_path):
         links = get_raw_tif_links(hurricane_name, toprint)
         res = tidy_up_tif_links(links, hurricane_name, toprint)
-        assert os.path.isfile(file_list_path) == True, "file should exist now!"
+        assert os.path.isfile(file_list_path) is True, "file should exist now!"
         return res
     else:
         data = open(file_list_path, "r")

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -1,10 +1,10 @@
 # Handle tif files
-from asyncio.format_helpers import _format_callback_source
+# from asyncio.format_helpers import _format_callback_source
 from genericpath import isfile
 import rasterio as rio
 import affine
 
-# Some useful thiings from rasterio
+# Some useful things from rasterio
 from rasterio.coords import BoundingBox
 
 # Handle geojson files
@@ -17,10 +17,13 @@ import requests
 from typing import List
 import sys
 import os
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from data_loading.utils import *
 
-def get_raw_tif_links(hurricane_name = DEFAULT_HURRICANE, toprint = True) -> List:
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from src.data_loading.utils import DEFAULT_HURRICANE, FILE_LIST_PREFIX, FILE_LIST_SUFFIX, PATH_TO_TIDIED_FILELISTS
+from src.data_loading.utils import print_message
+
+
+def get_raw_tif_links(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True) -> List:
     """
     Get a list of tif links for the hurricane with hurricane_name
     The list must exist on github
@@ -28,16 +31,17 @@ def get_raw_tif_links(hurricane_name = DEFAULT_HURRICANE, toprint = True) -> Lis
     filename = hurricane_name + FILE_LIST_SUFFIX
     file_list_path = FILE_LIST_PREFIX + filename
     response = requests.get(file_list_path)
-    assert response.status_code == 200, f"Unsuccessful request! Status code: {response.status_code}" +\
-        "\nThis may because you input an incorrect name for the hurricane"
-    data = response.text 
-    assert data != None, "No data!"
+    assert response.status_code == 200, f"Unsuccessful request! Status code: {response.status_code}" + \
+                                        "\nThis may because you input an incorrect name for the hurricane"
+    data = response.text
+    assert data is not None, "No data!"
     L = data.split("\n")
     links = [link.strip() for link in L if ".tif" in link]
     print_message(toprint, f"There are in total {len(links)} links.")
     return links
 
-def tidy_up_tif_links(links: List, hurricane_name, toprint = True, overwrite = False) -> List:
+
+def tidy_up_tif_links(links: List, hurricane_name: str, toprint: bool = True, overwrite: bool = False) -> List:
     """
     Given a list of tif links, will discard links that are useless
     Will then save the tidied list of links in data/processed/digital-globe-file-list-tidied
@@ -58,28 +62,29 @@ def tidy_up_tif_links(links: List, hurricane_name, toprint = True, overwrite = F
                 return get_tidied_tif_links(hurricane_name)
     if not os.path.isdir(PATH_TO_TIDIED_FILELISTS):
         os.mkdir(PATH_TO_TIDIED_FILELISTS)
-    res = [] 
+    res = []
     before_count = len(links)
     print_message(toprint, f"Tidying up a total of {before_count} links...")
     # Only want tif files with band >= 3
-    for (link,idx) in zip(links, list(range(before_count))):
-        print_message(toprint, f"{idx+1}/{before_count}", end="\r")
+    for (link, idx) in zip(links, list(range(before_count))):
+        print_message(toprint, f"{idx + 1}/{before_count}", end="\r")
         try:
             src = rio.open(link)
             if src.count >= 3:
                 res.append(link)
         except:
-            pass 
+            pass
     after_count = len(res)
     print_message(toprint, f"Before: {before_count} links \nAfter: {after_count} links")
     path = os.path.join(PATH_TO_TIDIED_FILELISTS, hurricane_name)
     f = open(path, "w")
     for link in res:
-        f.write(link+"\n")
+        f.write(link + "\n")
     f.close()
     return res
 
-def get_tidied_tif_links(hurricane_name = DEFAULT_HURRICANE, toprint = True) -> List:
+
+def get_tidied_tif_links(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True) -> List:
     """
     Get a list of tidied tif links for the hurricane with hurricane_name
     If the tidied file list does not exist, will look for raw data & tidy up
@@ -97,14 +102,15 @@ def get_tidied_tif_links(hurricane_name = DEFAULT_HURRICANE, toprint = True) -> 
         links = [link.strip() for link in L if ".tif" in link]
         return links
 
-def find_useful_links_for_box(links: List, box: BoundingBox, toprint = True) -> List:
+
+def find_useful_links_for_box(links: List, box: BoundingBox, toprint: bool = True) -> List:
     """
     Find useful tiff links that overlap with the bounding box
     """
     before_count = len(links)
     res = []
     for (link, idx) in zip(links, list(range(before_count))):
-        print_message(toprint, f"{idx+1}/{before_count}")
+        print_message(toprint, f"{idx + 1}/{before_count}")
         src = rio.open(link)
         if not rio.coords.disjoint_bounds(box, src.bounds):
             res.append(link)
@@ -112,7 +118,8 @@ def find_useful_links_for_box(links: List, box: BoundingBox, toprint = True) -> 
     print_message(toprint, f"Before: {before_count} links \nAfter: {after_count} links")
     return res
 
-def make_bounding_box_and_find_useful_links(left, bottom, right, top, links, toprint = True) -> tuple:
+
+def make_bounding_box_and_find_useful_links(left: float, bottom: float, right: float, top: float, links: List, toprint: bool = True) -> tuple:
     """
     PARAMETERS:
     ---
@@ -134,7 +141,8 @@ def make_bounding_box_and_find_useful_links(left, bottom, right, top, links, top
     print_message(toprint, f"Found {len(post_event_links)} post event links")
     return (box, useful_pre_event_links, useful_post_event_links)
 
-def get_list_of_bounds_for_hurricane(hurricane_name = DEFAULT_HURRICANE, toprint = True) -> dict:
+
+def get_list_of_bounds_for_hurricane(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True) -> dict:
     """
     RETURNS:
     ---

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -168,7 +168,14 @@ def find_useful_links_for_box(links: List, box: BoundingBox, toprint: bool = Tru
     return res
 
 
-def make_bounding_box_and_find_useful_links(left: float, bottom: float, right: float, top: float, links: List, toprint: bool = True) -> tuple:
+def make_bounding_box_and_find_useful_links(
+        left: float,
+        bottom: float,
+        right: float,
+        top: float,
+        links: List,
+        toprint: bool = True
+) -> tuple:
     """
     Parameters
     ----------

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -91,18 +91,18 @@ def tidy_up_tif_links(links: List, hurricane_name: str, toprint: bool = True, ov
     for idx, link in enumerate(links):
         print_message(toprint, f"{idx + 1}/{before_count}", end="\r")
         try:
-            src = rio.open(link)
-            if src.count >= 3:
-                res.append(link)
+            with rio.open(link) as src:
+                if src.count >= 3:
+                    res.append(link)
         except rio.errors.RasterioIOError:
             pass
     after_count = len(res)
     print_message(toprint, f"Before: {before_count} links \nAfter: {after_count} links")
     path = os.path.join(PATH_TO_TIDIED_FILELISTS, hurricane_name)
-    f = open(path, "w")
-    for link in res:
-        f.write(link + "\n")
-    f.close()
+
+    with open(path, "w") as f:
+        for link in res:
+            f.write(link + "\n")
     return res
 
 

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -87,7 +87,6 @@ def tidy_up_tif_links(links: List, hurricane_name: str, toprint: bool = True, ov
     before_count = len(links)
     print_message(toprint, f"Tidying up a total of {before_count} links...")
     # Only want tif files with band >= 3
-    # for (link, idx) in zip(links, list(range(before_count))):
     for idx, link in enumerate(links):
         print_message(toprint, f"{idx + 1}/{before_count}", end="\r")
         try:

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -53,8 +53,8 @@ def get_raw_tif_links(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = T
 
 def tidy_up_tif_links(links: List, hurricane_name: str, toprint: bool = True, overwrite: bool = False) -> List:
     """
-    Given a list of tif links, will discard links that are useless
-    Will then save the tidied list of links in data/processed/digital-globe-file-list-tidied
+    Given a list of tif links, will discard links that are useless, i.e. having less than 3 bands.
+    Will then save the tidied list of links in ./data/processed/digital-globe-file-list-tidied
     
     Parameters
     ----------

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -25,6 +25,18 @@ def get_raw_tif_links(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = T
     """
     Get a list of tif links for the hurricane with hurricane_name
     The list must exist on github
+
+    Parameters
+    ----------
+    hurricane_name : str
+        Name of the hurricane to get the raw tif links
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
+
+    Returns
+    -------
+    links : list
+        list of the links of the tif files to download
     """
     filename = hurricane_name + FILE_LIST_SUFFIX
     file_list_path = FILE_LIST_PREFIX + filename
@@ -44,11 +56,21 @@ def tidy_up_tif_links(links: List, hurricane_name: str, toprint: bool = True, ov
     Given a list of tif links, will discard links that are useless
     Will then save the tidied list of links in data/processed/digital-globe-file-list-tidied
     
-    PARAMETERS
-    ---
-        links: a list of links
-        toprint: whether or not to print progress
-        overwrite: if exists hurricane_file_list_tidied, whether or not to overwrite
+    Parameters
+    ----------
+    links : list
+        list of links
+    hurricane_name : str
+        name of the hurricane to use
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
+    overwrite : bool, optional
+        bool to overwrite hurricane_file_list_tidied if True, default False
+
+    Returns
+    -------
+    res : list
+        list of tidy up links
     """
     if len(links) == 0:
         raise ValueError("Empty list of links!")
@@ -88,6 +110,18 @@ def get_tidied_tif_links(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool 
     """
     Get a list of tidied tif links for the hurricane with hurricane_name
     If the tidied file list does not exist, will look for raw data & tidy up
+
+    Parameters
+    ----------
+    hurricane_name : str
+        name of the hurricane to use
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
+
+    Returns
+    -------
+    list
+        list of links of the tifs
     """
     file_list_path = os.path.join(PATH_TO_TIDIED_FILELISTS, hurricane_name)
     if not os.path.isfile(file_list_path):
@@ -106,6 +140,20 @@ def get_tidied_tif_links(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool 
 def find_useful_links_for_box(links: List, box: BoundingBox, toprint: bool = True) -> List:
     """
     Find useful tiff links that overlap with the bounding box
+
+    Parameters
+    ----------
+    links : list
+        list of the links to use
+    box : rasterio.coords.BoundingBox
+        boundingBox to use
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
+
+    Returns
+    -------
+    res : list
+        list of the links that overlap with the box
     """
     before_count = len(links)
     res = []
@@ -122,14 +170,21 @@ def find_useful_links_for_box(links: List, box: BoundingBox, toprint: bool = Tru
 
 def make_bounding_box_and_find_useful_links(left: float, bottom: float, right: float, top: float, links: List, toprint: bool = True) -> tuple:
     """
-    PARAMETERS:
-    ---
-        left, bottom, right top: for making the bounding box
-        links: list of links
-    
-    RETURNS:
-    ---
-        (boundingBox, useful-pre-event-links, useful-post-event-links)
+    Parameters
+    ----------
+    left : float
+    bottom : float
+    right : float
+    top : float
+        coordinates for the bounding box
+    links: list
+        list of the links to use
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
+
+    Returns
+    -------
+    (boundingBox, useful-pre-event-links, useful-post-event-links)
     """
     box = BoundingBox(left, bottom, right, top)
     pre_event_links = [link for link in links if "pre-event" in link]
@@ -145,11 +200,19 @@ def make_bounding_box_and_find_useful_links(left: float, bottom: float, right: f
 
 def get_list_of_bounds_for_hurricane(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True) -> dict:
     """
-    RETURNS:
-    ---
-        A dictionary, res, with keys: pre, post
-        res["pre"]: list of bounds of the sources obtained from pre_event_links
-        res["post"]: list of bounds of the sources obtained from post_event_links
+    Parameters
+    ----------
+    hurricane_name : str, optional
+        name of the hurricane to use, default DEFAULT_HURRICANE i.e. irma
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
+
+    Returns
+    -------
+    res : dict
+        dictionary of the links with the following structure:
+            key is "pre" is the list of bounds of the sources obtained from pre_event_links
+            key is "post" is the list of bounds of the sources obtained from post_event_links
     """
     res = dict()
     good_links = get_tidied_tif_links(hurricane_name, toprint)

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -72,7 +72,7 @@ def tidy_up_tif_links(links: List, hurricane_name: str, toprint: bool = True, ov
             src = rio.open(link)
             if src.count >= 3:
                 res.append(link)
-        except:
+        except rio.errors.RasterioIOError:
             pass
     after_count = len(res)
     print_message(toprint, f"Before: {before_count} links \nAfter: {after_count} links")

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -1,26 +1,24 @@
 # Handle tif files
 # from asyncio.format_helpers import _format_callback_source
-from genericpath import isfile
+# from genericpath import isfile
 import rasterio as rio
-import affine
+# import affine
 
 # Some useful things from rasterio
 from rasterio.coords import BoundingBox
-
-# Handle geojson files
-import geopandas as gpd
 
 # Web scraping
 import requests
 
 # Others
-from typing import List
 import sys
 import os
+from typing import List
 
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 from src.data_loading.utils import DEFAULT_HURRICANE, FILE_LIST_PREFIX, FILE_LIST_SUFFIX, PATH_TO_TIDIED_FILELISTS
 from src.data_loading.utils import print_message
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 
 def get_raw_tif_links(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True) -> List:

--- a/src/data_loading/tif_links_utils.py
+++ b/src/data_loading/tif_links_utils.py
@@ -53,7 +53,8 @@ def tidy_up_tif_links(links: List, hurricane_name: str, toprint: bool = True, ov
     if len(links) == 0:
         raise ValueError("Empty list of links!")
     if not overwrite:
-        # Check if tidied file exists
+        # Check if tidied file exists and if so get_tided_tif_links
+        # maybe redundant from the way this function is called
         if os.path.isdir(PATH_TO_TIDIED_FILELISTS):
             path = os.path.join(PATH_TO_TIDIED_FILELISTS, hurricane_name)
             if os.path.isfile(path):

--- a/src/data_loading/utils.py
+++ b/src/data_loading/utils.py
@@ -1,6 +1,6 @@
-import sys
 import os
 import math
+
 
 PATH_TO_SRC = os.path.join(os.path.dirname(__file__), '..')
 PATH_TO_DIR = os.path.join(PATH_TO_SRC, '..')

--- a/src/data_loading/utils.py
+++ b/src/data_loading/utils.py
@@ -41,9 +41,9 @@ def check_if_file_exist(path: str, delete_if_exist: bool) -> bool:
 
     Parameters
     ----------
-    path : str,
+    path : str
         path of the file to check
-    delete_if_exist : bool,
+    delete_if_exist : bool
         bool to overwrite file, True to overwrite
     """
     if os.path.isfile(path):

--- a/src/data_loading/utils.py
+++ b/src/data_loading/utils.py
@@ -11,15 +11,17 @@ PATH_TO_PATCHES = os.path.join(PATH_TO_DATA_PROCESSED, "patches")
 PATH_TO_GEOJSONS = os.path.join(PATH_TO_DATA_PROCESSED, "geojsons")
 PATH_TO_TIDIED_FILELISTS = os.path.join(PATH_TO_DATA_PROCESSED, "digital-globe-file-lists-tidied")
 
-FILE_LIST_PREFIX = "https://raw.githubusercontent.com/Chestnut-lol/predicting-cat-5-damage-to-buildings/main/data/raw/digital-globe-file-lists/" 
-FILE_LIST_SUFFIX = "_file_list.txt" 
+FILE_LIST_PREFIX = "https://raw.githubusercontent.com/Chestnut-lol/predicting-cat-5-damage-to-buildings/main/data/raw/digital-globe-file-lists/"
+FILE_LIST_SUFFIX = "_file_list.txt"
 DEFAULT_HURRICANE = "irma"
 
-earth_radius = 6371*10**(3)
+earth_radius = 6371 * 10 ** 3
 
-def print_message(toprint: bool, message: str, end = "\n"):
+
+def print_message(toprint: bool, message: str, end="\n") -> None:
     if toprint:
         print(message)
+
 
 def check_if_file_exist(path: str, delete_if_exist: bool) -> bool:
     if os.path.isfile(path):
@@ -27,11 +29,13 @@ def check_if_file_exist(path: str, delete_if_exist: bool) -> bool:
             os.remove(path)
             return False
         else:
-            return True 
+            return True
     return False
 
-def convert_meters_to_deg(meters):
-    return (180*meters)/(earth_radius*math.pi)
 
-def convert_deg_to_meters(deg):
-    return (earth_radius*math.pi*deg)/180
+def convert_meters_to_deg(meters: float) -> float:
+    return (180 * meters) / (earth_radius * math.pi)
+
+
+def convert_deg_to_meters(deg: float) -> float:
+    return (earth_radius * math.pi * deg) / 180

--- a/src/data_loading/utils.py
+++ b/src/data_loading/utils.py
@@ -15,7 +15,7 @@ FILE_LIST_PREFIX = "https://raw.githubusercontent.com/Chestnut-lol/predicting-ca
 FILE_LIST_SUFFIX = "_file_list.txt"
 DEFAULT_HURRICANE = "irma"
 
-earth_radius = 6371 * 10 ** 3
+earth_radius = 6371 * 10**3
 
 
 def print_message(toprint: bool, message: str, end="\n") -> None:

--- a/src/data_loading/utils.py
+++ b/src/data_loading/utils.py
@@ -37,6 +37,15 @@ def print_message(toprint: bool, message: str, end: Optional[str] = "\n") -> Non
 
 
 def check_if_file_exist(path: str, delete_if_exist: bool) -> bool:
+    """Check if file exist
+
+    Parameters
+    ----------
+    path: str,
+        path of the file to check
+    delete_if_exist: bool,
+        bool to overwrite file, True to overwrite
+    """
     if os.path.isfile(path):
         if delete_if_exist:
             os.remove(path)
@@ -47,8 +56,12 @@ def check_if_file_exist(path: str, delete_if_exist: bool) -> bool:
 
 
 def convert_meters_to_deg(meters: float) -> float:
+    """Convert meters to deg on the Earth
+    """
     return (180 * meters) / (earth_radius * math.pi)
 
 
 def convert_deg_to_meters(deg: float) -> float:
+    """Converts deg to meters on the Earth
+    """
     return (earth_radius * math.pi * deg) / 180

--- a/src/data_loading/utils.py
+++ b/src/data_loading/utils.py
@@ -1,6 +1,8 @@
 import os
 import math
 
+from typing import Optional
+
 
 PATH_TO_SRC = os.path.join(os.path.dirname(__file__), '..')
 PATH_TO_DIR = os.path.join(PATH_TO_SRC, '..')
@@ -18,9 +20,20 @@ DEFAULT_HURRICANE = "irma"
 earth_radius = 6371 * 10**3
 
 
-def print_message(toprint: bool, message: str, end="\n") -> None:
+def print_message(toprint: bool, message: str, end: Optional[str] = "\n") -> None:
+    """Helper function to print if toprint is True
+
+    Parameters
+    ----------
+    toprint : bool
+        if True print message, otherwise nothing
+    message : str
+        str to print
+    end : str, optional
+        end of line str to pass to print(), default "\n"
+    """
     if toprint:
-        print(message)
+        print(message, end=end)
 
 
 def check_if_file_exist(path: str, delete_if_exist: bool) -> bool:

--- a/src/data_loading/utils.py
+++ b/src/data_loading/utils.py
@@ -41,9 +41,9 @@ def check_if_file_exist(path: str, delete_if_exist: bool) -> bool:
 
     Parameters
     ----------
-    path: str,
+    path : str,
         path of the file to check
-    delete_if_exist: bool,
+    delete_if_exist : bool,
         bool to overwrite file, True to overwrite
     """
     if os.path.isfile(path):

--- a/src/data_loading/vector_data_utils.py
+++ b/src/data_loading/vector_data_utils.py
@@ -56,7 +56,7 @@ def get_vector_data_links(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool
     return links
 
 
-def load_vector_data_link(vector_data_link, hurricane_name: str = DEFAULT_HURRICANE) -> str:
+def load_vector_data_link(vector_data_link: str, hurricane_name: str = DEFAULT_HURRICANE) -> str:
     """
     Given a link to the vector data, will download the (zip) file & extract it 
     Will save the file in the correct directory in /data

--- a/src/data_loading/vector_data_utils.py
+++ b/src/data_loading/vector_data_utils.py
@@ -139,12 +139,14 @@ def load_all_vector_data_for_hurricane(hurricane_name: str = DEFAULT_HURRICANE, 
     """
     links = get_vector_data_links(hurricane_name, toprint)
     count = len(links)
-    print_message(toprint, "Extracting files...")
     if count == 0:
         raise ValueError("No links available!")
-    for (link, idx) in zip(links, list(range(count))):
+
+    print_message(toprint, "Extracting files...")
+    for idx, link in enumerate(links):
         print_message(toprint, f"{idx + 1}/{count}")
         destination_dir = load_vector_data_link(link, hurricane_name)
+
     print_message(toprint, f"Extracted files can be found in {destination_dir}")
     geojson_files = find_all_files_with_extension_in_dir(destination_dir, ".geojson", [])
     print_message(toprint, f"There are {len(geojson_files)} geojson files available")

--- a/src/data_loading/vector_data_utils.py
+++ b/src/data_loading/vector_data_utils.py
@@ -21,7 +21,7 @@ import zipfile
 import sys
 import os
 
-from src.data_loading.utils import *
+from src.data_loading.utils import DEFAULT_HURRICANE, FILE_LIST_SUFFIX, FILE_LIST_PREFIX, print_message, PATH_TO_DATA_RAW, PATH_TO_DIR, PATH_TO_GEOJSONS
 from src.data_loading.tif_links_utils import get_list_of_bounds_for_hurricane
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))

--- a/src/data_loading/vector_data_utils.py
+++ b/src/data_loading/vector_data_utils.py
@@ -31,6 +31,18 @@ def get_vector_data_links(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool
     """
     Get a list of vector data links for the hurricane with hurricane_name
     The list must exist on github
+
+    Parameters
+    ----------
+    hurricane_name : str, optional
+        name of the hurricane to use, default DEFAULT_HURRICANE i.e. irma
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
+
+    Returns
+    -------
+    links : list
+        list of the links of the vector files to download
     """
     filename = hurricane_name + FILE_LIST_SUFFIX
     file_list_path = FILE_LIST_PREFIX + filename
@@ -48,6 +60,18 @@ def load_vector_data_link(vector_data_link, hurricane_name: str = DEFAULT_HURRIC
     """
     Given a link to the vector data, will download the (zip) file & extract it 
     Will save the file in the correct directory in /data
+
+    Parameters
+    ----------
+    vector_data_link : str
+        string of the link to the vector data
+    hurricane_name : str, optional
+        name of the hurricane to use, default DEFAULT_HURRICANE i.e. irma
+
+    Returns
+    -------
+    destination_dir : str
+        path to vector data unzip directory
     """
     # Download and extract the zip file
     filename = vector_data_link.split("/")[-1]  # name of the zip file
@@ -68,12 +92,23 @@ def load_vector_data_link(vector_data_link, hurricane_name: str = DEFAULT_HURRIC
 
 def find_all_files_with_extension_in_dir(dirname: str, desired_extension: str, files: Optional[List] = None) -> List:
     """
-    Given a directory, finds a list of paths to files with extension 
-    
-    EXAMPLE:
-    --- 
-    Using desired_extension = ".geojson", will return a list of paths to all
-    geojson files in the directory 
+    Given a directory, recursively finds a list of paths to files with extension.
+    For instance, with desired_extension = ".geojson", will return a list of paths to all
+    geojson files in the directory dirname
+
+    Parameters
+    ----------
+    dirname : str
+        name of the directory the look for files
+    desired_extension : str
+        extension wanted for the files
+    files : list, optional
+        optional list of the files to append to, default is None
+
+    Returns
+    -------
+    files : list
+        list of the found files with the specific extension
     """
     if files is None:
         files = []
@@ -90,9 +125,17 @@ def find_all_files_with_extension_in_dir(dirname: str, desired_extension: str, f
 
 def load_all_vector_data_for_hurricane(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True) -> List:
     """
-    RETURNS
-    ---
-        files: a list of paths to all the geojson files related to hurricane_name
+    Parameters
+    ----------
+    hurricane_name : str, optional
+        name of the hurricane to use, default DEFAULT_HURRICANE i.e. irma
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
+
+    Returns
+    -------
+    files : list
+        a list of paths to all the geojson files related to hurricane_name
     """
     links = get_vector_data_links(hurricane_name, toprint)
     count = len(links)
@@ -111,13 +154,21 @@ def load_all_vector_data_for_hurricane(hurricane_name: str = DEFAULT_HURRICANE, 
 def combine_all_vector_data(hurricane_name: str, toprint: bool, overwrite: bool):
     """
     Combines all geojson files for the hurricane into one geojson file
-    The combined file will be saved in data/processed/geojson
+    The combined file will be saved in ./data/processed/geojson
 
-    PARAMETERS:
-    ---
-        hurricane_name: name of the hurricane
-        toprint: whether or not to print progress
-        overwrite: whether or not to overwrite existing processed vector data
+    Parameters
+    ----------
+    hurricane_name : str
+        name of the hurricane to use
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
+    overwrite : bool
+        bool to overwrite existing processed vector data
+
+    Returns
+    -------
+    res : geopandas.geodataframe.GeoDataFrame
+        GeoDataFrame of the concatenated (if needed) of all vector data associated to hurricane_name
     """
     # This is the path to the processed vector data file
     if not os.path.isdir(PATH_TO_GEOJSONS):
@@ -142,6 +193,21 @@ def combine_all_vector_data(hurricane_name: str, toprint: bool, overwrite: bool)
 
 
 def combine_all_vector_data_and_save_for_hurricane(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True, overwrite: bool = False):
+    """
+
+    Parameters
+    ----------
+    hurricane_name : str, optional
+        name of the hurricane to use, default DEFAULT_HURRICANE i.e. irma
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
+    overwrite : bool, optional
+        bool to overwrite file in geojsons directory, default False
+
+    Returns
+    -------
+    trimmed_filtered :
+    """
     # This is the path to the processed vector data file
     if not os.path.isdir(PATH_TO_GEOJSONS):
         os.mkdir(PATH_TO_GEOJSONS)
@@ -174,15 +240,33 @@ def combine_all_vector_data_and_save_for_hurricane(hurricane_name: str = DEFAULT
 
 
 def check_point_in_bounding_box(point: Point, box: BoundingBox) -> bool:
+    """
+
+    Parameters
+    ----------
+    point : shapely.geometry.point.Point
+    box : rasterio.coords.BoundingBox
+
+    Returns
+    -------
+    bool
+        True if point is in box
+    """
     return (box.left < point.x < box.right) and (box.bottom < point.y < box.top)
 
 
 def exist_link_containing_point(point: Point, bounds_list: List) -> bool:
     """
-    PARAMETERS
-    ---
-        point: a Point object from shapely.geometry.point
-        bounds_list: a list of BoundingBox objects
+    Parameters
+    ----------
+    point : shapely.geometry.point.Point
+    bounds_list : list
+        list of rasterio.coords.BoundingBox
+
+    Returns
+    -------
+    bool
+        True if there is at least a box in bounds_list which contains point
     """
     for bound in bounds_list:
         if check_point_in_bounding_box(point, bound):
@@ -192,11 +276,21 @@ def exist_link_containing_point(point: Point, bounds_list: List) -> bool:
 
 def trim_gdf(gdf: gpd.GeoDataFrame, hurricane_name: str, toprint: bool):
     """
-    This trims down the geodataframe 
-    and adds two extra cols: 
+    Trims down the geodataframe and adds two extra cols:
         exist_pre_event_imagery
         exist_post_event_imagery
-    We only keep the points that we have image for
+    Only keeping the points that have image associated
+
+    Parameters
+    ---------
+    gdf : geopandas.geodataframe.GeoDataFrame
+    hurricane_name : str
+        name of the hurricane to use
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
+
+    Returns
+    -------
     """
     print_message(toprint, "Getting list of bounds...")
     bounds_dict = get_list_of_bounds_for_hurricane(hurricane_name, toprint)
@@ -230,10 +324,15 @@ def trim_gdf(gdf: gpd.GeoDataFrame, hurricane_name: str, toprint: bool):
 
 def find_countries_for_point(point: Point) -> str:
     """
-    Find the country that the point is in
+    Find the country which contains the point
+
+    Parameters
+    ----------
+    point : shapely.geometry.point.Point
     
-    RETURNS:
-    ---
+    Returns
+    -------
+    str
         The country/countries that the point is in, separated by commas
     """
     cs = [c.name for c in cbb.country_subunits_containing_point(point.x, point.y)]
@@ -241,6 +340,18 @@ def find_countries_for_point(point: Point) -> str:
 
 
 def add_country_names(gdf: gpd.GeoDataFrame, hurricane_name: str, toprint: bool) -> None:
+    """
+    Add countries to the GeoDataFrame which were in the path of the hurricane given by hurricane_name
+
+    Parameters
+    ----------
+    gdf : geopandas.geodataframe.GeoDataFrame
+        geopandas dataframe to add country to
+    hurricane_name : str
+        name of the hurricane to use
+    toprint : bool, optional
+        bool to be passed to print_message helper function, see print_message(), default True
+    """
     gdf["country"] = gdf.geometry.apply(
         lambda point: find_countries_for_point(point)
     )

--- a/src/data_loading/vector_data_utils.py
+++ b/src/data_loading/vector_data_utils.py
@@ -10,21 +10,24 @@ import pandas as pd
 import numpy as np
 # Each building label is represented as a Point object
 # From shapely
-from shapely.geometry.point import Point 
+from shapely.geometry.point import Point
 # Finds the country
 import country_bounding_boxes as cbb
 from rasterio.coords import BoundingBox
 
 # Others
-from typing import List
+from typing import List, Optional
 import zipfile
 import sys
 import os
-sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
-from data_loading.utils import *
-from data_loading.tif_links_utils import get_list_of_bounds_for_hurricane
 
-def get_vector_data_links(hurricane_name = DEFAULT_HURRICANE, toprint = True) -> List:
+from src.data_loading.utils import *
+from src.data_loading.tif_links_utils import get_list_of_bounds_for_hurricane
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+
+def get_vector_data_links(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True) -> List:
     """
     Get a list of vector data links for the hurricane with hurricane_name
     The list must exist on github
@@ -33,22 +36,23 @@ def get_vector_data_links(hurricane_name = DEFAULT_HURRICANE, toprint = True) ->
     file_list_path = FILE_LIST_PREFIX + filename
     response = requests.get(file_list_path)
     assert response.status_code == 200, f"Unsuccessful request! Status code: {response.status_code}"
-    data = response.text 
-    assert data != None, "No data!"
+    data = response.text
+    assert data is not None, "No data!"
     L = data.split("\n")
     links = [link.strip() for link in L if ".zip" in link]
     print_message(toprint, f"There are in total {len(links)} links.")
     return links
 
-def load_vector_data_link(vector_data_link, hurricane_name = DEFAULT_HURRICANE):
+
+def load_vector_data_link(vector_data_link, hurricane_name: str = DEFAULT_HURRICANE) -> str:
     """
     Given a link to the vector data, will download the (zip) file & extract it 
     Will save the file in the correct directory in /data
     """
     # Download and extract the zip file
-    filename = vector_data_link.split("/")[-1] # name of the zip file
+    filename = vector_data_link.split("/")[-1]  # name of the zip file
     destination_dir = os.path.join(PATH_TO_DATA_RAW, f"{hurricane_name}-vector-data")
-    
+
     if not os.path.isdir(destination_dir):
         os.mkdir(destination_dir)
     if not os.path.isfile(filename):
@@ -58,10 +62,11 @@ def load_vector_data_link(vector_data_link, hurricane_name = DEFAULT_HURRICANE):
         zip_ref.extractall(destination_dir)
 
     # After extraction, delete the zip file
-    os.remove(os.path.join(PATH_TO_DIR,filename))
+    os.remove(os.path.join(PATH_TO_DIR, filename))
     return destination_dir
 
-def find_all_files_with_extension_in_dir(dirname, desired_extension, files = []):
+
+def find_all_files_with_extension_in_dir(dirname: str, desired_extension: str, files: Optional[List] = None) -> List:
     """
     Given a directory, finds a list of paths to files with extension 
     
@@ -70,6 +75,8 @@ def find_all_files_with_extension_in_dir(dirname, desired_extension, files = [])
     Using desired_extension = ".geojson", will return a list of paths to all
     geojson files in the directory 
     """
+    if files is None:
+        files = []
     for name in os.scandir(dirname):
         if os.path.isdir(name):
             files = find_all_files_with_extension_in_dir(name.path, desired_extension, files)
@@ -80,7 +87,8 @@ def find_all_files_with_extension_in_dir(dirname, desired_extension, files = [])
                     files.append(name.path)
     return files
 
-def load_all_vector_data_for_hurricane(hurricane_name = DEFAULT_HURRICANE, toprint = True) -> List:
+
+def load_all_vector_data_for_hurricane(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True) -> List:
     """
     RETURNS
     ---
@@ -92,14 +100,15 @@ def load_all_vector_data_for_hurricane(hurricane_name = DEFAULT_HURRICANE, topri
     if count == 0:
         raise ValueError("No links available!")
     for (link, idx) in zip(links, list(range(count))):
-        print_message(toprint, f"{idx+1}/{count}")
+        print_message(toprint, f"{idx + 1}/{count}")
         destination_dir = load_vector_data_link(link, hurricane_name)
     print_message(toprint, f"Extracted files can be found in {destination_dir}")
     geojson_files = find_all_files_with_extension_in_dir(destination_dir, ".geojson", [])
     print_message(toprint, f"There are {len(geojson_files)} geojson files available")
     return geojson_files
 
-def combine_all_vector_data(hurricane_name, toprint, overwrite):
+
+def combine_all_vector_data(hurricane_name: str, toprint: bool, overwrite: bool):
     """
     Combines all geojson files for the hurricane into one geojson file
     The combined file will be saved in data/processed/geojson
@@ -115,7 +124,7 @@ def combine_all_vector_data(hurricane_name, toprint, overwrite):
         os.mkdir(PATH_TO_GEOJSONS)
     path = os.path.join(PATH_TO_GEOJSONS, hurricane_name + ".geojson")
     # If there is already a processed data file
-    if os.path.isfile(path) and not overwrite: 
+    if os.path.isfile(path) and not overwrite:
         return gpd.read_file(path)
     print_message(toprint, f"Retrieving all vector data files for hurricane {hurricane_name}...")
     files = load_all_vector_data_for_hurricane(hurricane_name, toprint)
@@ -132,13 +141,13 @@ def combine_all_vector_data(hurricane_name, toprint, overwrite):
     return res
 
 
-def combine_all_vector_data_and_save_for_hurricane(hurricane_name = DEFAULT_HURRICANE, toprint = True, overwrite = False):
+def combine_all_vector_data_and_save_for_hurricane(hurricane_name: str = DEFAULT_HURRICANE, toprint: bool = True, overwrite: bool = False):
     # This is the path to the processed vector data file
     if not os.path.isdir(PATH_TO_GEOJSONS):
         os.mkdir(PATH_TO_GEOJSONS)
     path = os.path.join(PATH_TO_GEOJSONS, hurricane_name + ".geojson")
     # If there is already a processed data file
-    if os.path.isfile(path) and not overwrite: 
+    if os.path.isfile(path) and not overwrite:
         return gpd.read_file(path)
 
     res = combine_all_vector_data(hurricane_name, toprint, overwrite=True)
@@ -148,12 +157,12 @@ def combine_all_vector_data_and_save_for_hurricane(hurricane_name = DEFAULT_HURR
     print_message(toprint, "Trimming...")
     trimmed = trim_gdf(gpd.GeoDataFrame(res), hurricane_name, toprint)
     print_message(toprint, f"There are {len(trimmed)} buildings in total after trimming")
-    
+
     # We only want points that are buildings, not other things
     print_message(toprint, "Filtering...")
     trimmed_filtered = trimmed.loc[trimmed.label == "Flooded / Damaged Building"].copy()
     print_message(toprint, f"There are {len(trimmed_filtered)} buildings in total after filtering")
-    
+
     # Add country names
     print_message(toprint, "Adding country names...")
     add_country_names(trimmed_filtered, hurricane_name, toprint)
@@ -163,8 +172,10 @@ def combine_all_vector_data_and_save_for_hurricane(hurricane_name = DEFAULT_HURR
     print_message(toprint, f"Successfully saved trimmed vector data as a geojson file to:\n{path}")
     return trimmed_filtered
 
-def check_point_in_bounding_box(point: Point, box: BoundingBox):
-    return (box.left < point.x < box.right) and  (box.bottom < point.y < box.top)
+
+def check_point_in_bounding_box(point: Point, box: BoundingBox) -> bool:
+    return (box.left < point.x < box.right) and (box.bottom < point.y < box.top)
+
 
 def exist_link_containing_point(point: Point, bounds_list: List) -> bool:
     """
@@ -178,7 +189,8 @@ def exist_link_containing_point(point: Point, bounds_list: List) -> bool:
             return True
     return False
 
-def trim_gdf(gdf: gpd.GeoDataFrame, hurricane_name, toprint):
+
+def trim_gdf(gdf: gpd.GeoDataFrame, hurricane_name: str, toprint: bool):
     """
     This trims down the geodataframe 
     and adds two extra cols: 
@@ -199,7 +211,7 @@ def trim_gdf(gdf: gpd.GeoDataFrame, hurricane_name, toprint):
         )
     )
     print_message(toprint, f"There are {len(gdf.loc[gdf.exist_post_event_imagery])} buildings with post-event imagery")
-    
+
     gdf["exist_pre_event_imagery"] = gdf.geometry.apply(
         lambda point: exist_link_containing_point(
             point=point,
@@ -207,13 +219,14 @@ def trim_gdf(gdf: gpd.GeoDataFrame, hurricane_name, toprint):
         )
     )
     print_message(toprint, f"There are {len(gdf.loc[gdf.exist_pre_event_imagery])} buildings with pre-event imagery")
-    
+
     return gdf.loc[
         np.logical_or(
             gdf.exist_pre_event_imagery.to_numpy(),
             gdf.exist_post_event_imagery.to_numpy(),
         )
     ]
+
 
 def find_countries_for_point(point: Point) -> str:
     """
@@ -226,7 +239,8 @@ def find_countries_for_point(point: Point) -> str:
     cs = [c.name for c in cbb.country_subunits_containing_point(point.x, point.y)]
     return ", ".join(cs)
 
-def add_country_names(gdf: gpd.GeoDataFrame, hurricane_name, toprint):
+
+def add_country_names(gdf: gpd.GeoDataFrame, hurricane_name: str, toprint: bool) -> None:
     gdf["country"] = gdf.geometry.apply(
         lambda point: find_countries_for_point(point)
     )
@@ -241,10 +255,11 @@ def add_country_names(gdf: gpd.GeoDataFrame, hurricane_name, toprint):
                     countries[c] += 1
         print(f"The countries in the dataset for {hurricane_name} are: ")
         for c in countries.keys():
-            print(c," ",countries[c])
+            print(c, " ", countries[c])
         print("---------------")
         print("Total: ", sum([countries[c] for c in countries.keys()]))
 
+
 if __name__ == "__main__":
-    df = combine_all_vector_data_and_save_for_hurricane("test",toprint=True,overwrite=True)
+    df = combine_all_vector_data_and_save_for_hurricane("test", toprint=True, overwrite=True)
     print(df.info())


### PR DESCRIPTION
1. Refactor the whole code in `./src` to make it easier to read.
2. Sorting and cleaning the imports: 
- Sorting the imports as `import` followed by `from` imports and then by local-specific imports
- Removed wildcard imports `*` as they can cause shadowing names and can prevent IDE from finding references to the functions
3. Added `docstring` for all functions
4. Added `type hint` for all functions